### PR TITLE
Fix bug caused by removal of Request.headers and Request.received_headers

### DIFF
--- a/coherence/backends/appletrailers_storage.py
+++ b/coherence/backends/appletrailers_storage.py
@@ -28,7 +28,7 @@ class AppleTrailerProxy(ReverseProxyUriResource):
         ReverseProxyUriResource.__init__(self, uri)
 
     def render(self, request):
-        request.requestHeaders.setRawHeaders('user-agent',['QuickTime/7.6.2 (qtver=7.6.2;os=Windows NT 5.1Service Pack 3)'])
+        request.requestHeaders.setRawHeaders('user-agent', ['QuickTime/7.6.2 (qtver=7.6.2;os=Windows NT 5.1Service Pack 3)'])
         return ReverseProxyUriResource.render(self, request)
 
 

--- a/coherence/backends/appletrailers_storage.py
+++ b/coherence/backends/appletrailers_storage.py
@@ -28,7 +28,7 @@ class AppleTrailerProxy(ReverseProxyUriResource):
         ReverseProxyUriResource.__init__(self, uri)
 
     def render(self, request):
-        request.received_headers['user-agent'] = 'QuickTime/7.6.2 (qtver=7.6.2;os=Windows NT 5.1Service Pack 3)'
+        request.requestHeaders.setRawHeaders('user-agent',['QuickTime/7.6.2 (qtver=7.6.2;os=Windows NT 5.1Service Pack 3)'])
         return ReverseProxyUriResource.render(self, request)
 
 

--- a/coherence/backends/gallery2_storage.py
+++ b/coherence/backends/gallery2_storage.py
@@ -25,7 +25,7 @@ class ProxyGallery2Image(ReverseProxyUriResource):
         ReverseProxyUriResource.__init__(self, uri)
 
     def render(self, request):
-        del request.received_headers['referer']
+        request.requestHeaders.removeHeader('referer')
         return ReverseProxyUriResource.render(self, request)
 
 

--- a/coherence/backends/picasa_storage.py
+++ b/coherence/backends/picasa_storage.py
@@ -32,8 +32,7 @@ class PicasaProxy(ReverseProxyUriResource):
         ReverseProxyUriResource.__init__(self, uri)
 
     def render(self, request):
-        if request.received_headers.has_key('referer'):
-            del request.received_headers['referer']
+        request.requestHeaders.removeHeader('referer')
         return ReverseProxyUriResource.render(self, request)
 
 

--- a/coherence/upnp/core/event.py
+++ b/coherence/upnp/core/event.py
@@ -44,7 +44,7 @@ class EventServer(resource.Resource, log.Loggable):
         request.setResponseCode(200)
 
         command = {'method': request.method, 'path': request.path}
-        headers = request.received_headers
+        headers = request.getAllHeaders()
         louie.send('UPnP.Event.Server.message_received', None, command, headers, data)
 
         if request.code != 200:
@@ -112,7 +112,7 @@ class EventSubscriptionServer(resource.Resource, log.Loggable):
         request.setResponseCode(200)
 
         command = {'method': request.method, 'path': request.path}
-        headers = request.received_headers
+        headers = request.getAllHeaders()
         louie.send('UPnP.Event.Client.message_received', None, command, headers, data)
 
         if request.code != 200:
@@ -157,7 +157,7 @@ class EventSubscriptionServer(resource.Resource, log.Loggable):
         request.setResponseCode(200)
 
         command = {'method': request.method, 'path': request.path}
-        headers = request.received_headers
+        headers = request.getAllHeaders()
         louie.send('UPnP.Event.Client.message_received', None, command, headers, data)
 
         if request.code != 200:

--- a/coherence/upnp/core/utils.py
+++ b/coherence/upnp/core/utils.py
@@ -350,10 +350,10 @@ class ReverseProxyResource(proxy.ReverseProxyResource):
         # RFC 2616 tells us that we can omit the port if it's the default port,
         # but we have to provide it otherwise
         if self.port == 80:
-            request.requestHeaders.setRawHeaders('host',[self.host])
+            request.requestHeaders.setRawHeaders('host', [self.host])
         else:
             hostname = "%s:%d" % (self.host, self.port)
-            request.requestHeaders.setRawHeaders('host',[hostname])
+            request.requestHeaders.setRawHeaders('host', [hostname])
         request.content.seek(0, 0)
         qs = urlparse.urlparse(request.uri)[4]
         if qs == '':

--- a/coherence/upnp/core/utils.py
+++ b/coherence/upnp/core/utils.py
@@ -350,9 +350,10 @@ class ReverseProxyResource(proxy.ReverseProxyResource):
         # RFC 2616 tells us that we can omit the port if it's the default port,
         # but we have to provide it otherwise
         if self.port == 80:
-            request.received_headers['host'] = self.host
+            request.requestHeaders.setRawHeaders('host',[self.host])
         else:
-            request.received_headers['host'] = "%s:%d" % (self.host, self.port)
+            hostname = "%s:%d" % (self.host, self.port)
+            request.requestHeaders.setRawHeaders('host',[hostname])
         request.content.seek(0, 0)
         qs = urlparse.urlparse(request.uri)[4]
         if qs == '':
@@ -598,7 +599,7 @@ class BufferFile(static.File):
             # won't be overwritten.
             request.method = 'HEAD'
             return ''
-        #print "StaticFile out", request.headers, request.code
+        #print "StaticFile out", request.responseHeaders, request.code
 
         # return data
         # size is the byte position to stop sending, not how many bytes to send

--- a/coherence/upnp/devices/media_server.py
+++ b/coherence/upnp/devices/media_server.py
@@ -276,7 +276,7 @@ class MSRoot(resource.Resource, log.Loggable):
     def requestFinished(self, result, id, request):
         self.info("finished, remove %d from connection table", id)
         self.info("finished, sentLength: %d chunked: %d code: %d", request.sentLength, request.chunked, request.code)
-        self.info("finished %r", request.headers)
+        self.info("finished %r", request.responseHeaders)
         self.server.connection_manager_server.remove_connection(id)
 
     def import_file(self, name, request):
@@ -326,7 +326,7 @@ class MSRoot(resource.Resource, log.Loggable):
                     self.warning('%s request with content-length %s header - sanitizing',
                                     request.method,
                                     headers['content-length'])
-                    del request.received_headers['content-length']
+                    request.requestHeaders.removeHeader('content-length')
                 self.debug('data', )
                 if len(request.content.getvalue()) > 0:
                     """ shall we remove that?


### PR DESCRIPTION
This fixes a bug that occurs when twisted >= 16.0.0 is used - an AttriibuteError is generated such as:

```
File "/home/phil/.virtualenvs/tb/local/lib/python2.7/site-packages/Coherence-0.6.7-py2.7.egg/coherence/upnp/core/event.py", line 47, in render_NOTIFY
    headers = request.received_headers
exceptions.AttributeError: Request instance has no attribute 'received_headers'
```

I have changed it to use Request.responseHeaders and Request.requestHeaders  instead
