### PR TITLE
Store value range data in Variables

### DIFF
--- a/coherence/upnp/core/service.py
+++ b/coherence/upnp/core/service.py
@@ -366,17 +366,18 @@ class Service(log.Loggable):
                                                                'n/a',
                                                                instance, send_events,
                                                                data_type, values)
-                """ we need to do this here, as there we don't get there our
-                    {urn:schemas-beebits-net:service-1-0}X_withVendorDefines
-                    attibute there
-                """
                 allowed_range = var_node.find('{%s}allowedValueRange' % ns)
                 if allowed_range:
                     allowed_range_dict = {}
                     for item in allowed_range:
                         namespace_uri, tag = item.tag[1:].split("}", 1)
-                        allowed_range_dict[tag] = item.text
+                        if tag in ['maximum','minimum','step']:
+                            allowed_range_dict[tag] = item.text
                     self._variables.get(instance)[name].set_allowed_value_range(**allowed_range_dict)
+                """ we need to do this here, as there we don't get there our
+                    {urn:schemas-beebits-net:service-1-0}X_withVendorDefines
+                    attibute there
+                """
                 self._variables.get(instance)[name].has_vendor_values = True
 
             #print 'service parse:', self, self.device

--- a/coherence/upnp/core/service.py
+++ b/coherence/upnp/core/service.py
@@ -371,7 +371,7 @@ class Service(log.Loggable):
                     allowed_range_dict = {}
                     for item in allowed_range:
                         namespace_uri, tag = item.tag[1:].split("}", 1)
-                        if tag in ['maximum','minimum','step']:
+                        if tag in ['maximum', 'minimum', 'step']:
                             allowed_range_dict[tag] = item.text
                     self._variables.get(instance)[name].set_allowed_value_range(**allowed_range_dict)
                 """ we need to do this here, as there we don't get there our

--- a/coherence/upnp/core/service.py
+++ b/coherence/upnp/core/service.py
@@ -370,6 +370,13 @@ class Service(log.Loggable):
                     {urn:schemas-beebits-net:service-1-0}X_withVendorDefines
                     attibute there
                 """
+                allowed_range = var_node.find('{%s}allowedValueRange' % ns)
+                if allowed_range:
+                    allowed_range_dict = {}
+                    for item in allowed_range:
+                        namespace_uri, tag = item.tag[1:].split("}", 1)
+                        allowed_range_dict[tag] = item.text
+                    self._variables.get(instance)[name].set_allowed_value_range(**allowed_range_dict)
                 self._variables.get(instance)[name].has_vendor_values = True
 
             #print 'service parse:', self, self.device


### PR DESCRIPTION
Coherence currently ignores data provided about a `variable` regarding possible maximum and minimum (and step) values, even though there is an attribute `allowed_value_range` to hold these details.

This PR fixes this by inspecting the service descriptor data