### PR TITLE
Fix bug in generated XML code

### DIFF
--- a/coherence/upnp/devices/basics.py
+++ b/coherence/upnp/devices/basics.py
@@ -93,13 +93,17 @@ class RootDeviceXML(static.Data):
 
         if device_type == 'MediaServer':
             x = ET.SubElement(d, 'dev:X_DLNADOC')
+            x.attrib['xmlns:dev'] = "urn:schemas-dlna-org:device-1-0"
             x.text = 'DMS-1.50'
             x = ET.SubElement(d, 'dev:X_DLNADOC')
+            x.attrib['xmlns:dev'] = "urn:schemas-dlna-org:device-1-0"
             x.text = 'M-DMS-1.50'
         elif device_type == 'MediaRenderer':
             x = ET.SubElement(d, 'dev:X_DLNADOC')
+            x.attrib['xmlns:dev'] = "urn:schemas-dlna-org:device-1-0"
             x.text = 'DMR-1.50'
             x = ET.SubElement(d, 'dev:X_DLNADOC')
+            x.attrib['xmlns:dev'] = "urn:schemas-dlna-org:device-1-0"
             x.text = 'M-DMR-1.50'
 
         if len(dlna_caps) > 0:
@@ -107,6 +111,7 @@ class RootDeviceXML(static.Data):
                 dlna_caps = [dlna_caps]
             for cap in dlna_caps:
                 x = ET.SubElement(d, 'dev:X_DLNACAP')
+                x.attrib['xmlns:dev'] = "urn:schemas-dlna-org:device-1-0"
                 x.text = cap
 
         ET.SubElement(d, 'deviceType').text = device_type_uri


### PR DESCRIPTION
The current XML code generation creates an error whenever a `MediaServer` or `MediaRenderer` plugin is created. 

```
2016-11-20 20:14:50,822 WARNING mediarenderer: Tingbot MediaRenderer (MPlayerPlayer'>) activated with 0c5bec2a-8fca-4c28-be2a-4e9b6ccbcd78 (media_renderer.py:143)
2016-11-20 20:14:50,844 WARNING device: Invalid device description received from 'http://192.168.1.52:41703/0c5bec2a-8fca-4c28-be2a-4e9b6ccbcd78/description-2.xml' (device.py:541)
```

This is because the `dev:X_DLNADOC` tag does not have a namespace specified for `dev`. This PR fixes this